### PR TITLE
Optional Serde support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Empty string means no features will be enabled
+        features: ["", "--features serde"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -26,8 +30,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Run tests ${{ matrix.features }}
+        run: cargo test --verbose ${{ matrix.features }}
 
   fmt:
     name: fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ exclude = [
 
 [dependencies]
 magpie = {version = "0.9", features = ["serde"]}
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -1,5 +1,6 @@
 use crate::parse::{Game, Position};
 use magpie::othello::{OthelloBoard, Stone};
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -1,5 +1,6 @@
 use crate::parse::{Game, Position};
 use magpie::othello::{OthelloBoard, Stone};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 // Maximum number of moves a standard game of 8x8 Othello can have
@@ -58,12 +59,14 @@ impl From<magpie::othello::OthelloError> for InferError {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct OrderedGame {
     pub moves: Vec<Move>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Move {
     pub stone: Stone,
     pub bitboard: u64,

--- a/src/parse/header.rs
+++ b/src/parse/header.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 const HEADER_LENGTH: usize = 16;
 
@@ -57,7 +58,8 @@ pub enum HeaderError {
     InvalidP2Record,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Header {
     pub file_creation_date: FileCreationDate,
     pub n1: u32,
@@ -68,7 +70,8 @@ pub struct Header {
     pub p3: u8,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct FileCreationDate {
     pub century: u8,
     pub year: u8,
@@ -76,7 +79,8 @@ pub struct FileCreationDate {
     pub day: u8,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub enum BoardSize {
     EightSquared,
     TenSquared,

--- a/src/parse/header.rs
+++ b/src/parse/header.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/parse/wthor.rs
+++ b/src/parse/wthor.rs
@@ -3,6 +3,7 @@ use crate::parse::header::BoardSize;
 use crate::parse::header::Header;
 use crate::parse::header::HeaderError;
 use std::convert::TryInto;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/parse/wthor.rs
+++ b/src/parse/wthor.rs
@@ -2,8 +2,9 @@ use crate::parse::header;
 use crate::parse::header::BoardSize;
 use crate::parse::header::Header;
 use crate::parse::header::HeaderError;
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 const HEADER_LENGTH: usize = 16;
 
@@ -102,7 +103,8 @@ pub enum RecordError {
     InvalidMove,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Position {
     pub rank: u8,
     pub file: u8,
@@ -120,13 +122,15 @@ impl From<HeaderError> for WthorError {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct WthorFile {
     pub header: Header,
     pub games: Vec<Game>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Game {
     pub tournament_label_number: u16,
     pub black_player_number: u16,


### PR DESCRIPTION
Added optional Serde support. Enabling a feature flag will allow the user to serialize to whatever format they wish, and back.

Closes #2 

Signed-off-by: Emil Englesson englesson.emil@gmail.com